### PR TITLE
changed input-group type to input group append

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,8 +123,8 @@
           <div class="card-body">
             <div class="input-group">
               <input type="text" class="form-control" placeholder="Search for...">
-              <span class="input-group-btn">
-                <button class="btn btn-secondary" type="button">Go!</button>
+              <span class="input-group-append">
+                <button class="btn btn-success" type="button">Go!</button>
               </span>
             </div>
           </div>


### PR DESCRIPTION
Bootstrap has a button append class to prepend or append a button directly to an input field leaving no spaces between the two - that looks much better than the normal input-group-btn.
## Before
![input-group-btn](https://i.imgur.com/h6mDcYh.png)
## After
![input-group-append](https://i.imgur.com/KnwHFED.png)